### PR TITLE
Implement FastAPI pairs trader with Polygon

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,14 @@
-# stat-arb-pairs-platform
+# Stat-Arb Pairs Trader
+
+This is a minimal pairs trading application built with FastAPI. Historical and live market data comes from [Polygon.io](https://polygon.io). Execution is simulated only.
+
+## Quick Start
+
+```bash
+export POLYGON_API_KEY="pk_your_key"  # optional for back-tests, required for live mode
+python -m venv .venv && source .venv/bin/activate
+pip install -r requirements.txt
+uvicorn trader.main:app --reload
+```
+
+Open `http://localhost:8000/docs` for the API. Back-tests work without an API key using `yfinance` data. Live mode requires `POLYGON_API_KEY`.

--- a/mypy.ini
+++ b/mypy.ini
@@ -1,0 +1,3 @@
+[mypy]
+ignore_missing_imports = True
+strict = True

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,12 @@
+fastapi>=0.116
+uvicorn[standard]>=0.29
+pydantic>=2.7
+sqlmodel>=0.0.16
+pandas>=2.2
+numpy>=2.3
+statsmodels>=0.14
+polygon-api-client>=1.12
+yfinance>=0.2
+websockets>=12.0
+plotly>=5.22
+python-multipart>=0.0.9

--- a/trader/data.py
+++ b/trader/data.py
@@ -1,0 +1,57 @@
+from __future__ import annotations
+
+import asyncio
+import json
+import os
+from datetime import datetime
+from typing import AsyncIterator, Iterable
+
+import pandas as pd
+import websockets
+import yfinance as yf
+from polygon import RESTClient
+
+API_KEY = os.getenv("POLYGON_API_KEY")
+_client = RESTClient(API_KEY) if API_KEY else None
+
+
+def fetch_bars_polygon(symbol: str, start: str, end: str, timeframe: str = "day") -> pd.DataFrame:
+    """Fetch historical bars from Polygon or fall back to yfinance."""
+    if _client is None:
+        df = yf.download(symbol, start=start, end=end, interval="1d" if timeframe == "day" else "1m")
+        df.index.name = "timestamp"
+        return df
+
+    timespan = "day" if timeframe == "day" else "minute"
+    aggs = _client.get_aggs(symbol, 1, timespan, start, end)
+    records = [
+        {
+            "timestamp": datetime.fromtimestamp(a.timestamp / 1000),
+            "open": a.open,
+            "high": a.high,
+            "low": a.low,
+            "close": a.close,
+            "volume": a.volume,
+        }
+        for a in aggs
+    ]
+    df = pd.DataFrame(records).set_index("timestamp")
+    return df
+
+
+async def stream_bars_polygon(symbols: Iterable[str]) -> AsyncIterator[dict[str, object]]:
+    """Yield live minute bars from the Polygon WebSocket."""
+    if API_KEY is None:
+        raise RuntimeError("POLYGON_API_KEY required for live streaming")
+
+    uri = "wss://socket.polygon.io/stocks"
+    params = ",".join(f"A.{s}" for s in symbols)
+    async with websockets.connect(uri) as ws:
+        await ws.send(json.dumps({"action": "auth", "params": API_KEY}))
+        await ws.send(json.dumps({"action": "subscribe", "params": params}))
+        async for message in ws:
+            data = json.loads(message)
+            for bar in data:
+                if bar.get("ev") == "AM":
+                    yield bar
+            await asyncio.sleep(0)  # allow cancellation

--- a/trader/live.py
+++ b/trader/live.py
@@ -1,0 +1,65 @@
+from __future__ import annotations
+
+from collections import deque
+from dataclasses import dataclass, field
+from datetime import datetime
+from typing import Deque, cast
+
+import numpy as np
+
+
+@dataclass
+class TradeEvent:
+    timestamp: datetime
+    position: int
+
+
+@dataclass
+class LivePairTrader:
+    symbol_a: str
+    symbol_b: str
+    window: int = 60
+    threshold: float = 1.0
+    prices_a: Deque[float] = field(default_factory=lambda: deque(maxlen=60))
+    prices_b: Deque[float] = field(default_factory=lambda: deque(maxlen=60))
+    position: int = 0
+    trades: list[TradeEvent] = field(default_factory=list)
+
+    def on_bar(self, bar: dict[str, object]) -> dict[str, object] | None:
+        symbol = str(bar.get("sym"))
+        price = float(cast(float, bar.get("c", 0)))
+        ts_value = cast(float, bar.get("s") or bar.get("t") or 0)
+        ts = datetime.fromtimestamp(ts_value / 1000)
+
+        if symbol == self.symbol_a:
+            self.prices_a.append(price)
+        elif symbol == self.symbol_b:
+            self.prices_b.append(price)
+        else:
+            return None
+
+        if len(self.prices_a) < self.window or len(self.prices_b) < self.window:
+            return None
+
+        spread_series = np.log(np.array(self.prices_a)) - np.log(np.array(self.prices_b))
+        z = float((spread_series[-1] - spread_series.mean()) / spread_series.std())
+
+        old_position = self.position
+        if self.position == 0:
+            if z > self.threshold:
+                self.position = -1
+            elif z < -self.threshold:
+                self.position = 1
+        elif abs(z) < 0.2:
+            self.position = 0
+
+        if old_position != self.position:
+            self.trades.append(TradeEvent(timestamp=ts, position=self.position))
+
+        return {
+            "ts": ts.isoformat(),
+            "price_a": self.prices_a[-1],
+            "price_b": self.prices_b[-1],
+            "z": float(z),
+            "position": self.position,
+        }

--- a/trader/main.py
+++ b/trader/main.py
@@ -1,0 +1,41 @@
+from __future__ import annotations
+
+
+import numpy as np
+from fastapi import FastAPI, WebSocket, WebSocketDisconnect
+
+from .data import fetch_bars_polygon, stream_bars_polygon
+from .live import LivePairTrader
+
+app = FastAPI(title="Stat-Arb Pairs Trader")
+
+
+@app.get("/backtest")  # type: ignore[misc]
+def backtest(symbol_a: str, symbol_b: str, start: str, end: str) -> dict[str, object]:
+    df_a = fetch_bars_polygon(symbol_a, start, end)
+    df_b = fetch_bars_polygon(symbol_b, start, end)
+    df = df_a.join(df_b, lsuffix="_a", rsuffix="_b", how="inner")
+    spread = np.log(df["close_a"]) - np.log(df["close_b"])
+    z = (spread - spread.mean()) / spread.std()
+    position = np.where(z > 1, -1, np.where(z < -1, 1, 0))
+    equity = np.cumsum(position * np.diff(np.concatenate([[0.0], spread])))
+    return {
+        "z": z.tolist(),
+        "equity": equity.tolist(),
+    }
+
+
+@app.websocket("/ws/live")  # type: ignore[misc]
+async def ws_live(websocket: WebSocket, symbol_a: str, symbol_b: str) -> None:
+    await websocket.accept()
+    trader = LivePairTrader(symbol_a, symbol_b)
+    try:
+        async for bar in stream_bars_polygon([symbol_a, symbol_b]):
+            data = trader.on_bar(bar)
+            if data is not None:
+                await websocket.send_json(data)
+    except WebSocketDisconnect:
+        return
+    except Exception:
+        await websocket.close()
+        raise


### PR DESCRIPTION
## Summary
- add project setup and requirements
- implement Polygon data helpers and live trading logic
- provide FastAPI app with backtest and live websocket endpoints

## Testing
- `ruff check .`
- `mypy --strict .`


------
https://chatgpt.com/codex/tasks/task_e_686c59e4f124832b83e90d962f15505e